### PR TITLE
Fix a type error trying to iterate non-array

### DIFF
--- a/settable/fieldtypes/SetTableFieldType.php
+++ b/settable/fieldtypes/SetTableFieldType.php
@@ -162,7 +162,7 @@ class SetTableFieldType extends BaseFieldType
             }
 
             // Minor fix for Backwards-compatibility - migrate old data into new key
-            foreach ($value as $key => $val) {
+            foreach ((array) $value as $key => $val) {
                 if (is_numeric($key)) {
                     $value['row'.($key+1)] = $val;
                     unset($value[$key]);


### PR DESCRIPTION
I'm not sure why this happened, or if possibly you can flag the backwards-style data format detection in a way that makes this loop not run all the time, but at least it crashed in my setup on entries without a value for the field, after I updated the field definition.

Considering the code I'd doubt that typecasting poses a problem, but its probably more easily fixable when you know what the heck this migration really does :)
